### PR TITLE
Set minimum Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,5 +28,8 @@
     "webpack": "^4.42.1",
     "webpack-cli": "^3.3.11",
     "webpack-node-externals": "^1.7.2"
+  },
+  "engines": {
+    "node": ">=12.11.0"
   }
 }


### PR DESCRIPTION
This project uses worker_threads, a module that has been considered
stable on Node.js since 12.11.0:
https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V12.md#12.11.0